### PR TITLE
Fix incorrect object templating `stdClass::__set_state` -> `(object)`

### DIFF
--- a/src/PhpCode.php
+++ b/src/PhpCode.php
@@ -125,6 +125,7 @@ class PhpCode extends PhpTemplate
     public static function varExport($value)
     {
         $result = var_export($value, 1);
+        $result = str_replace("stdClass::__set_state", "(object)", $result);
         $result = str_replace("array (\n", "array(\n", $result);
         $result = str_replace('  ', '    ', $result);
         $result = str_replace("array(\n)", "array()", $result);


### PR DESCRIPTION
Hello!

While I'm using enum (over #ref) I have problem with incorrect code-generation; in result I have code like:
```
'schemas' => 
            stdClass::__set_state(array(
                 'Any-key-1' => 
                stdClass::__set_state(array(
                     'enum' => 
                    array(
                        0 => 'key-1',
                        1 => 'key-2',
                        2 => 'key-3',
                    ),
                     'type' => 'string',
                )),
            )),
```
So, I made it simple fix.