### PR TITLE
PhpCode: Handle empty constant

### DIFF
--- a/src/PhpCode.php
+++ b/src/PhpCode.php
@@ -107,17 +107,21 @@ class PhpCode extends PhpTemplate
     {
         $phpName = preg_replace("/([^a-zA-Z0-9_]+)/", "_", $rawName);
         $phpName = trim($phpName, '_');
-        $phpName = self::fromCamelCase($phpName);
 
-        if (in_array(strtolower($phpName), self::$keywords)) {
-            $phpName = '_' . $phpName;
-        }
+        if ($phpName) {
+            $phpName = self::fromCamelCase($phpName);
 
-        if (!$phpName) {
+            if (in_array(strtolower($phpName), self::$keywords)) {
+                $phpName = '_' . $phpName;
+            }
+
+            if (is_numeric($phpName[0])) {
+                $phpName = 'const_' . $phpName;
+            }
+        } else {
             $phpName = 'const_' . substr(md5($rawName), 0, 6);
-        } elseif (is_numeric($phpName[0])) {
-            $phpName = 'const_' . $phpName;
         }
+
         return strtoupper($phpName);
     }
 

--- a/tests/src/PHPUnit/PhpCodeTest.php
+++ b/tests/src/PHPUnit/PhpCodeTest.php
@@ -7,6 +7,26 @@ use Swaggest\PhpCodeBuilder\PhpCode;
 
 class PhpCodeTest extends \PHPUnit_Framework_TestCase
 {
+    public function testMakePhpConstantName()
+    {
+        $this->assertSame('A', PhpCode::makePhpConstantName('a'));
+        $this->assertSame('ABC', PhpCode::makePhpConstantName('abc'));
+        $this->assertSame('A_B_C', PhpCode::makePhpConstantName('a*b##c'));
+        $this->assertSame('ABC', PhpCode::makePhpConstantName('_abc_'));
+        $this->assertSame('ABC', PhpCode::makePhpConstantName('__abc__'));
+        $this->assertSame('AB_C', PhpCode::makePhpConstantName('__AB__c__'));
+
+        // Keyword would be invalid.
+        $this->assertSame('_AS', PhpCode::makePhpConstantName('as'));
+
+        // Leading numeric would be invalid.
+        $this->assertSame('_1A', PhpCode::makePhpConstantName('1A'));
+
+        // Empty would be invalid.
+        $this->assertSame('CONST_CFCD20', PhpCode::makePhpConstantName('0'));
+        $this->assertSame('CONST_B14A7B', PhpCode::makePhpConstantName('_'));
+    }
+
     public function testFromCamelCase()
     {
         $this->assertSame('api_key', PhpCode::fromCamelCase('apiKey'));

--- a/tests/src/PHPUnit/PhpCodeTest.php
+++ b/tests/src/PHPUnit/PhpCodeTest.php
@@ -20,7 +20,7 @@ class PhpCodeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('_AS', PhpCode::makePhpConstantName('as'));
 
         // Leading numeric would be invalid.
-        $this->assertSame('_1A', PhpCode::makePhpConstantName('1A'));
+        $this->assertSame('CONST_1_A', PhpCode::makePhpConstantName('1A'));
 
         // Empty would be invalid.
         $this->assertSame('CONST_CFCD20', PhpCode::makePhpConstantName('0'));


### PR DESCRIPTION
When generating a constant name for a string, we were assuming that we'd
always be able to access `$phpName[0]`, but this isn't the case when
there are no "usable" characters in the original string (e.g., `0`, `_`,
`=`), resulting in an empty transformed string.

Rearrange the logic to make sure that we don't try to access the first
character of an empty string. This bug was surfaced by trying to create
an enum constant for the string `=`.