### PR TITLE
Add option to use title/description as class name part

### DIFF
--- a/src/JsonSchema/PhpBuilder.php
+++ b/src/JsonSchema/PhpBuilder.php
@@ -26,9 +26,6 @@ use Swaggest\PhpCodeBuilder\Property\PatternPropertySetter;
 use Swaggest\PhpCodeBuilder\Property\Setter;
 use Swaggest\PhpCodeBuilder\Types\TypeOf;
 
-/**
- * @todo properly process $ref, $schema property names
- */
 class PhpBuilder
 {
     const IMPORT_METHOD_PHPDOC_ID = '::import';
@@ -50,6 +47,12 @@ class PhpBuilder
     public $buildSetters = false;
     public $makeEnumConstants = false;
     public $skipSchemaDescriptions = false;
+
+    /**
+     * Use title/description where available instead of keyword in names
+     * @var bool
+     */
+    public $namesFromDescriptions = false;
 
     /**
      * Squish multiple $ref, a PHP class for each $ref will be created if false

--- a/tests/src/PHPUnit/OpenAPI3/GenTest.php
+++ b/tests/src/PHPUnit/OpenAPI3/GenTest.php
@@ -39,6 +39,7 @@ class GenTest extends \PHPUnit_Framework_TestCase
         $builder->buildSetters = true;
         $builder->makeEnumConstants = true;
         $builder->minimizeRefs = $this->minimizeRefs;
+        $builder->namesFromDescriptions = true;
 
         $builder->classCreatedHook = new ClassHookCallback(function (PhpClass $class, $path, $schema) use ($app, $appNs) {
             $desc = '';

--- a/tests/src/Tmp/OpenAPI3/Components.php
+++ b/tests/src/Tmp/OpenAPI3/Components.php
@@ -27,7 +27,7 @@ class Components extends ClassStructure
     /** @var string[][]|Response[] */
     public $responses;
 
-    /** @var string[][]|Parameter[]|mixed[]|ParameterLocationOneOf0[]|ParameterLocationOneOf1[]|ParameterLocationOneOf2[]|ParameterLocationOneOf3[] */
+    /** @var string[][]|Parameter[]|mixed[]|ParameterLocationParameterInPath[]|ParameterLocationParameterInQuery[]|ParameterLocationParameterInHeader[]|ParameterLocationParameterInCookie[] */
     public $parameters;
 
     /** @var string[][]|Example[] */
@@ -39,7 +39,7 @@ class Components extends ClassStructure
     /** @var string[][]|Header[]|mixed[] */
     public $headers;
 
-    /** @var string[][]|APIKeySecurityScheme[]|HTTPSecurityScheme[]|HTTPSecuritySchemeOneOf0[]|HTTPSecuritySchemeOneOf1[]|OAuth2SecurityScheme[]|OpenIdConnectSecurityScheme[] */
+    /** @var string[][]|APIKeySecurityScheme[]|HTTPSecurityScheme[]|HTTPSecuritySchemeBearer[]|HTTPSecuritySchemeNonBearer[]|OAuth2SecurityScheme[]|OpenIdConnectSecurityScheme[] */
     public $securitySchemes;
 
     /** @var string[][]|Link[] */
@@ -214,7 +214,7 @@ class Components extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
-     * @param string[][]|Parameter[]|mixed[]|ParameterLocationOneOf0[]|ParameterLocationOneOf1[]|ParameterLocationOneOf2[]|ParameterLocationOneOf3[] $parameters
+     * @param string[][]|Parameter[]|mixed[]|ParameterLocationParameterInPath[]|ParameterLocationParameterInQuery[]|ParameterLocationParameterInHeader[]|ParameterLocationParameterInCookie[] $parameters
      * @return $this
      * @codeCoverageIgnoreStart
      */
@@ -262,7 +262,7 @@ class Components extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
-     * @param string[][]|APIKeySecurityScheme[]|HTTPSecurityScheme[]|HTTPSecuritySchemeOneOf0[]|HTTPSecuritySchemeOneOf1[]|OAuth2SecurityScheme[]|OpenIdConnectSecurityScheme[] $securitySchemes
+     * @param string[][]|APIKeySecurityScheme[]|HTTPSecurityScheme[]|HTTPSecuritySchemeBearer[]|HTTPSecuritySchemeNonBearer[]|OAuth2SecurityScheme[]|OpenIdConnectSecurityScheme[] $securitySchemes
      * @return $this
      * @codeCoverageIgnoreStart
      */

--- a/tests/src/Tmp/OpenAPI3/HTTPSecurityScheme.php
+++ b/tests/src/Tmp/OpenAPI3/HTTPSecurityScheme.php
@@ -17,7 +17,7 @@ use Swaggest\JsonSchema\Structure\ClassStructure;
 
 /**
  * Built from #/definitions/HTTPSecurityScheme
- * @method static HTTPSecurityScheme|HTTPSecuritySchemeOneOf0|HTTPSecuritySchemeOneOf1 import($data, Context $options = null)
+ * @method static HTTPSecurityScheme|HTTPSecuritySchemeBearer|HTTPSecuritySchemeNonBearer import($data, Context $options = null)
  */
 class HTTPSecurityScheme extends ClassStructure
 {
@@ -54,8 +54,8 @@ class HTTPSecurityScheme extends ClassStructure
         $ownerSchema->additionalProperties = false;
         $patternProperty = new Schema();
         $ownerSchema->setPatternProperty('^x-', $patternProperty);
-        $ownerSchema->oneOf[0] = HTTPSecuritySchemeOneOf0::schema();
-        $ownerSchema->oneOf[1] = HTTPSecuritySchemeOneOf1::schema();
+        $ownerSchema->oneOf[0] = HTTPSecuritySchemeBearer::schema();
+        $ownerSchema->oneOf[1] = HTTPSecuritySchemeNonBearer::schema();
         $ownerSchema->required = array(
             self::names()->scheme,
             self::names()->type,

--- a/tests/src/Tmp/OpenAPI3/HTTPSecuritySchemeBearer.php
+++ b/tests/src/Tmp/OpenAPI3/HTTPSecuritySchemeBearer.php
@@ -12,9 +12,9 @@ use Swaggest\JsonSchema\Structure\ClassStructure;
 
 
 /**
- * Non Bearer
+ * Bearer
  */
-class HTTPSecuritySchemeOneOf1 extends ClassStructure
+class HTTPSecuritySchemeBearer extends ClassStructure
 {
     const BEARER = 'bearer';
 
@@ -28,15 +28,10 @@ class HTTPSecuritySchemeOneOf1 extends ClassStructure
     public static function setUpProperties($properties, Schema $ownerSchema)
     {
         $properties->scheme = new Schema();
-        $properties->scheme->not = new Schema();
-        $properties->scheme->not->enum = array(
+        $properties->scheme->enum = array(
             self::BEARER,
         );
-        $ownerSchema->not = new Schema();
-        $ownerSchema->not->required = array(
-            self::names()->bearerFormat,
-        );
-        $ownerSchema->description = "Non Bearer";
+        $ownerSchema->description = "Bearer";
     }
 
     /**

--- a/tests/src/Tmp/OpenAPI3/HTTPSecuritySchemeNonBearer.php
+++ b/tests/src/Tmp/OpenAPI3/HTTPSecuritySchemeNonBearer.php
@@ -12,9 +12,9 @@ use Swaggest\JsonSchema\Structure\ClassStructure;
 
 
 /**
- * Bearer
+ * Non Bearer
  */
-class HTTPSecuritySchemeOneOf0 extends ClassStructure
+class HTTPSecuritySchemeNonBearer extends ClassStructure
 {
     const BEARER = 'bearer';
 
@@ -28,10 +28,15 @@ class HTTPSecuritySchemeOneOf0 extends ClassStructure
     public static function setUpProperties($properties, Schema $ownerSchema)
     {
         $properties->scheme = new Schema();
-        $properties->scheme->enum = array(
+        $properties->scheme->not = new Schema();
+        $properties->scheme->not->enum = array(
             self::BEARER,
         );
-        $ownerSchema->description = "Bearer";
+        $ownerSchema->not = new Schema();
+        $ownerSchema->not->required = array(
+            self::names()->bearerFormat,
+        );
+        $ownerSchema->description = "Non Bearer";
     }
 
     /**

--- a/tests/src/Tmp/OpenAPI3/Operation.php
+++ b/tests/src/Tmp/OpenAPI3/Operation.php
@@ -36,7 +36,7 @@ class Operation extends ClassStructure
     /** @var string */
     public $operationId;
 
-    /** @var Parameter[]|mixed[]|ParameterLocationOneOf0[]|ParameterLocationOneOf1[]|ParameterLocationOneOf2[]|ParameterLocationOneOf3[]|string[][]|array */
+    /** @var Parameter[]|mixed[]|ParameterLocationParameterInPath[]|ParameterLocationParameterInQuery[]|ParameterLocationParameterInHeader[]|ParameterLocationParameterInCookie[]|string[][]|array */
     public $parameters;
 
     /** @var RequestBody|string[] */
@@ -191,7 +191,7 @@ class Operation extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
-     * @param Parameter[]|mixed[]|ParameterLocationOneOf0[]|ParameterLocationOneOf1[]|ParameterLocationOneOf2[]|ParameterLocationOneOf3[]|string[][]|array $parameters
+     * @param Parameter[]|mixed[]|ParameterLocationParameterInPath[]|ParameterLocationParameterInQuery[]|ParameterLocationParameterInHeader[]|ParameterLocationParameterInCookie[]|string[][]|array $parameters
      * @return $this
      * @codeCoverageIgnoreStart
      */

--- a/tests/src/Tmp/OpenAPI3/Parameter.php
+++ b/tests/src/Tmp/OpenAPI3/Parameter.php
@@ -17,7 +17,7 @@ use Swaggest\JsonSchema\Structure\ClassStructure;
 
 /**
  * Built from #/definitions/Parameter
- * @method static Parameter|ParameterLocationOneOf0|ParameterLocationOneOf1|ParameterLocationOneOf2|ParameterLocationOneOf3 import($data, Context $options = null)
+ * @method static Parameter|ParameterLocationParameterInPath|ParameterLocationParameterInQuery|ParameterLocationParameterInHeader|ParameterLocationParameterInCookie import($data, Context $options = null)
  */
 class Parameter extends ClassStructure
 {
@@ -173,10 +173,10 @@ class Parameter extends ClassStructure
         $ownerSchemaAllOf1->setFromRef('#/definitions/SchemaXORContent');
         $ownerSchema->allOf[1] = $ownerSchemaAllOf1;
         $ownerSchemaAllOf2 = new Schema();
-        $ownerSchemaAllOf2->oneOf[0] = ParameterLocationOneOf0::schema();
-        $ownerSchemaAllOf2->oneOf[1] = ParameterLocationOneOf1::schema();
-        $ownerSchemaAllOf2->oneOf[2] = ParameterLocationOneOf2::schema();
-        $ownerSchemaAllOf2->oneOf[3] = ParameterLocationOneOf3::schema();
+        $ownerSchemaAllOf2->oneOf[0] = ParameterLocationParameterInPath::schema();
+        $ownerSchemaAllOf2->oneOf[1] = ParameterLocationParameterInQuery::schema();
+        $ownerSchemaAllOf2->oneOf[2] = ParameterLocationParameterInHeader::schema();
+        $ownerSchemaAllOf2->oneOf[3] = ParameterLocationParameterInCookie::schema();
         $ownerSchemaAllOf2->description = "Parameter location";
         $ownerSchemaAllOf2->setFromRef('#/definitions/ParameterLocation');
         $ownerSchema->allOf[2] = $ownerSchemaAllOf2;

--- a/tests/src/Tmp/OpenAPI3/ParameterLocationParameterInCookie.php
+++ b/tests/src/Tmp/OpenAPI3/ParameterLocationParameterInCookie.php
@@ -12,26 +12,19 @@ use Swaggest\JsonSchema\Structure\ClassStructure;
 
 
 /**
- * Parameter in path
+ * Parameter in cookie
  */
-class ParameterLocationOneOf0 extends ClassStructure
+class ParameterLocationParameterInCookie extends ClassStructure
 {
-    const PATH = 'path';
+    const COOKIE = 'cookie';
 
-    const MATRIX = 'matrix';
-
-    const LABEL = 'label';
-
-    const SIMPLE = 'simple';
+    const FORM = 'form';
 
     /** @var mixed */
     public $in;
 
     /** @var mixed */
     public $style;
-
-    /** @var mixed */
-    public $required;
 
     /**
      * @param Properties|static $properties
@@ -41,23 +34,14 @@ class ParameterLocationOneOf0 extends ClassStructure
     {
         $properties->in = new Schema();
         $properties->in->enum = array(
-            self::PATH,
+            self::COOKIE,
         );
         $properties->style = new Schema();
         $properties->style->enum = array(
-            self::MATRIX,
-            self::LABEL,
-            self::SIMPLE,
+            self::FORM,
         );
-        $properties->style->default = "simple";
-        $properties->required = new Schema();
-        $properties->required->enum = array(
-            true,
-        );
-        $ownerSchema->description = "Parameter in path";
-        $ownerSchema->required = array(
-            self::names()->required,
-        );
+        $properties->style->default = "form";
+        $ownerSchema->description = "Parameter in cookie";
     }
 
     /**
@@ -80,18 +64,6 @@ class ParameterLocationOneOf0 extends ClassStructure
     public function setStyle($style)
     {
         $this->style = $style;
-        return $this;
-    }
-    /** @codeCoverageIgnoreEnd */
-
-    /**
-     * @param mixed $required
-     * @return $this
-     * @codeCoverageIgnoreStart
-     */
-    public function setRequired($required)
-    {
-        $this->required = $required;
         return $this;
     }
     /** @codeCoverageIgnoreEnd */

--- a/tests/src/Tmp/OpenAPI3/ParameterLocationParameterInHeader.php
+++ b/tests/src/Tmp/OpenAPI3/ParameterLocationParameterInHeader.php
@@ -14,7 +14,7 @@ use Swaggest\JsonSchema\Structure\ClassStructure;
 /**
  * Parameter in header
  */
-class ParameterLocationOneOf2 extends ClassStructure
+class ParameterLocationParameterInHeader extends ClassStructure
 {
     const HEADER = 'header';
 

--- a/tests/src/Tmp/OpenAPI3/ParameterLocationParameterInPath.php
+++ b/tests/src/Tmp/OpenAPI3/ParameterLocationParameterInPath.php
@@ -12,25 +12,26 @@ use Swaggest\JsonSchema\Structure\ClassStructure;
 
 
 /**
- * Parameter in query
+ * Parameter in path
  */
-class ParameterLocationOneOf1 extends ClassStructure
+class ParameterLocationParameterInPath extends ClassStructure
 {
-    const QUERY = 'query';
+    const PATH = 'path';
 
-    const FORM = 'form';
+    const MATRIX = 'matrix';
 
-    const SPACE_DELIMITED = 'spaceDelimited';
+    const LABEL = 'label';
 
-    const PIPE_DELIMITED = 'pipeDelimited';
-
-    const DEEP_OBJECT = 'deepObject';
+    const SIMPLE = 'simple';
 
     /** @var mixed */
     public $in;
 
     /** @var mixed */
     public $style;
+
+    /** @var mixed */
+    public $required;
 
     /**
      * @param Properties|static $properties
@@ -40,17 +41,23 @@ class ParameterLocationOneOf1 extends ClassStructure
     {
         $properties->in = new Schema();
         $properties->in->enum = array(
-            self::QUERY,
+            self::PATH,
         );
         $properties->style = new Schema();
         $properties->style->enum = array(
-            self::FORM,
-            self::SPACE_DELIMITED,
-            self::PIPE_DELIMITED,
-            self::DEEP_OBJECT,
+            self::MATRIX,
+            self::LABEL,
+            self::SIMPLE,
         );
-        $properties->style->default = "form";
-        $ownerSchema->description = "Parameter in query";
+        $properties->style->default = "simple";
+        $properties->required = new Schema();
+        $properties->required->enum = array(
+            true,
+        );
+        $ownerSchema->description = "Parameter in path";
+        $ownerSchema->required = array(
+            self::names()->required,
+        );
     }
 
     /**
@@ -73,6 +80,18 @@ class ParameterLocationOneOf1 extends ClassStructure
     public function setStyle($style)
     {
         $this->style = $style;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @param mixed $required
+     * @return $this
+     * @codeCoverageIgnoreStart
+     */
+    public function setRequired($required)
+    {
+        $this->required = $required;
         return $this;
     }
     /** @codeCoverageIgnoreEnd */

--- a/tests/src/Tmp/OpenAPI3/ParameterLocationParameterInQuery.php
+++ b/tests/src/Tmp/OpenAPI3/ParameterLocationParameterInQuery.php
@@ -12,13 +12,19 @@ use Swaggest\JsonSchema\Structure\ClassStructure;
 
 
 /**
- * Parameter in cookie
+ * Parameter in query
  */
-class ParameterLocationOneOf3 extends ClassStructure
+class ParameterLocationParameterInQuery extends ClassStructure
 {
-    const COOKIE = 'cookie';
+    const QUERY = 'query';
 
     const FORM = 'form';
+
+    const SPACE_DELIMITED = 'spaceDelimited';
+
+    const PIPE_DELIMITED = 'pipeDelimited';
+
+    const DEEP_OBJECT = 'deepObject';
 
     /** @var mixed */
     public $in;
@@ -34,14 +40,17 @@ class ParameterLocationOneOf3 extends ClassStructure
     {
         $properties->in = new Schema();
         $properties->in->enum = array(
-            self::COOKIE,
+            self::QUERY,
         );
         $properties->style = new Schema();
         $properties->style->enum = array(
             self::FORM,
+            self::SPACE_DELIMITED,
+            self::PIPE_DELIMITED,
+            self::DEEP_OBJECT,
         );
         $properties->style->default = "form";
-        $ownerSchema->description = "Parameter in cookie";
+        $ownerSchema->description = "Parameter in query";
     }
 
     /**

--- a/tests/src/Tmp/OpenAPI3/PathItem.php
+++ b/tests/src/Tmp/OpenAPI3/PathItem.php
@@ -35,7 +35,7 @@ class PathItem extends ClassStructure
     /** @var Server[]|array */
     public $servers;
 
-    /** @var Parameter[]|mixed[]|ParameterLocationOneOf0[]|ParameterLocationOneOf1[]|ParameterLocationOneOf2[]|ParameterLocationOneOf3[]|string[][]|array */
+    /** @var Parameter[]|mixed[]|ParameterLocationParameterInPath[]|ParameterLocationParameterInQuery[]|ParameterLocationParameterInHeader[]|ParameterLocationParameterInCookie[]|string[][]|array */
     public $parameters;
 
     /**
@@ -121,7 +121,7 @@ class PathItem extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
-     * @param Parameter[]|mixed[]|ParameterLocationOneOf0[]|ParameterLocationOneOf1[]|ParameterLocationOneOf2[]|ParameterLocationOneOf3[]|string[][]|array $parameters
+     * @param Parameter[]|mixed[]|ParameterLocationParameterInPath[]|ParameterLocationParameterInQuery[]|ParameterLocationParameterInHeader[]|ParameterLocationParameterInCookie[]|string[][]|array $parameters
      * @return $this
      * @codeCoverageIgnoreStart
      */


### PR DESCRIPTION
This PR adds an option to use schema description/title in generated class name instead of transitive keyword (`oneOf`, `not`, etc...) so that `HTTPSecuritySchemeOneOf0` could become `HTTPSecuritySchemeBearer`. 