### PR TITLE
Fix phpdoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.20] - 2019-10-02
+
+### Fixed
+- Missing return and argument phpdoc types for `array` and `mixed`.
 
 ## [0.2.19] - 2019-10-02
 
@@ -16,6 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Description trimming bug.
 
-[Unreleased]: https://github.com/swaggest/php-code-builder/compare/v0.2.19...HEAD
+[0.2.20]: https://github.com/swaggest/php-code-builder/compare/v0.2.19...v0.2.20
 [0.2.19]: https://github.com/swaggest/php-code-builder/compare/v0.2.18...v0.2.19
 [0.2.18]: https://github.com/swaggest/php-code-builder/compare/v0.2.17...v0.2.18

--- a/src/PhpNamedVar.php
+++ b/src/PhpNamedVar.php
@@ -118,9 +118,14 @@ class PhpNamedVar
     public function renderPhpDocValue($withName = false)
     {
         $tagValue = '';
+        $phpDocType = '';
         if ($this->type) {
-            $tagValue .= $this->type->renderPhpDocType();
+            $phpDocType = $this->type->renderPhpDocType();
         }
+        if (!trim($phpDocType)) {
+            $phpDocType = PhpStdType::TYPE_MIXED;
+        }
+        $tagValue .= $phpDocType;
         if ($withName) {
             $tagValue .= ' $' . $this->name;
         }

--- a/src/Types/ArrayOf.php
+++ b/src/Types/ArrayOf.php
@@ -44,7 +44,7 @@ class ArrayOf implements PhpAnyType
         if ($this->type instanceof OrType) {
             return $this->type->renderArrayPhpDocType();
         } elseif ($this->type === PhpStdType::mixed()) {
-            return '';
+            return 'array';
         } else {
             return $this->type->renderPhpDocType() . '[]';
         }

--- a/tests/src/PHPUnit/FunctionTest.php
+++ b/tests/src/PHPUnit/FunctionTest.php
@@ -36,7 +36,7 @@ PHP
 );
         $expected = <<<'PHP'
 /**
- * @param $arg1
+ * @param mixed $arg1
  * @param int $arg2
  */
 function test($arg1, $arg2)

--- a/tests/src/Tmp/OpenAPI3/APIKeySecurityScheme.php
+++ b/tests/src/Tmp/OpenAPI3/APIKeySecurityScheme.php
@@ -120,6 +120,7 @@ class APIKeySecurityScheme extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/AuthorizationCodeOAuthFlow.php
+++ b/tests/src/Tmp/OpenAPI3/AuthorizationCodeOAuthFlow.php
@@ -107,6 +107,7 @@ class AuthorizationCodeOAuthFlow extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/ClientCredentialsFlow.php
+++ b/tests/src/Tmp/OpenAPI3/ClientCredentialsFlow.php
@@ -89,6 +89,7 @@ class ClientCredentialsFlow extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/Components.php
+++ b/tests/src/Tmp/OpenAPI3/Components.php
@@ -316,6 +316,7 @@ class Components extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/Contact.php
+++ b/tests/src/Tmp/OpenAPI3/Contact.php
@@ -85,6 +85,7 @@ class Contact extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/DefinitionsSchema.php
+++ b/tests/src/Tmp/OpenAPI3/DefinitionsSchema.php
@@ -735,6 +735,7 @@ class DefinitionsSchema extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/Example.php
+++ b/tests/src/Tmp/OpenAPI3/Example.php
@@ -100,6 +100,7 @@ class Example extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/ExternalDocumentation.php
+++ b/tests/src/Tmp/OpenAPI3/ExternalDocumentation.php
@@ -71,6 +71,7 @@ class ExternalDocumentation extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/HTTPSecurityScheme.php
+++ b/tests/src/Tmp/OpenAPI3/HTTPSecurityScheme.php
@@ -112,6 +112,7 @@ class HTTPSecurityScheme extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/Header.php
+++ b/tests/src/Tmp/OpenAPI3/Header.php
@@ -310,6 +310,7 @@ class Header extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/ImplicitOAuthFlow.php
+++ b/tests/src/Tmp/OpenAPI3/ImplicitOAuthFlow.php
@@ -90,6 +90,7 @@ class ImplicitOAuthFlow extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/Info.php
+++ b/tests/src/Tmp/OpenAPI3/Info.php
@@ -136,6 +136,7 @@ class Info extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/License.php
+++ b/tests/src/Tmp/OpenAPI3/License.php
@@ -71,6 +71,7 @@ class License extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/Link.php
+++ b/tests/src/Tmp/OpenAPI3/Link.php
@@ -27,6 +27,7 @@ class Link extends ClassStructure
     /** @var string */
     public $operationRef;
 
+    /** @var array */
     public $parameters;
 
     /** @var mixed */
@@ -90,7 +91,7 @@ class Link extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
-     * @param $parameters
+     * @param array $parameters
      * @return $this
      * @codeCoverageIgnoreStart
      */
@@ -138,6 +139,7 @@ class Link extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/MediaType.php
+++ b/tests/src/Tmp/OpenAPI3/MediaType.php
@@ -136,6 +136,7 @@ class MediaType extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/OAuth2SecurityScheme.php
+++ b/tests/src/Tmp/OpenAPI3/OAuth2SecurityScheme.php
@@ -92,6 +92,7 @@ class OAuth2SecurityScheme extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/OAuthFlows.php
+++ b/tests/src/Tmp/OpenAPI3/OAuthFlows.php
@@ -99,6 +99,7 @@ class OAuthFlows extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/OpenAPI3Schema.php
+++ b/tests/src/Tmp/OpenAPI3/OpenAPI3Schema.php
@@ -184,6 +184,7 @@ class OpenAPI3Schema extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/OpenIdConnectSecurityScheme.php
+++ b/tests/src/Tmp/OpenAPI3/OpenIdConnectSecurityScheme.php
@@ -93,6 +93,7 @@ class OpenIdConnectSecurityScheme extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/Operation.php
+++ b/tests/src/Tmp/OpenAPI3/Operation.php
@@ -281,6 +281,7 @@ class Operation extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/Parameter.php
+++ b/tests/src/Tmp/OpenAPI3/Parameter.php
@@ -348,6 +348,7 @@ class Parameter extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/PasswordOAuthFlow.php
+++ b/tests/src/Tmp/OpenAPI3/PasswordOAuthFlow.php
@@ -89,6 +89,7 @@ class PasswordOAuthFlow extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/RequestBody.php
+++ b/tests/src/Tmp/OpenAPI3/RequestBody.php
@@ -88,6 +88,7 @@ class RequestBody extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/Response.php
+++ b/tests/src/Tmp/OpenAPI3/Response.php
@@ -129,6 +129,7 @@ class Response extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/Responses.php
+++ b/tests/src/Tmp/OpenAPI3/Responses.php
@@ -117,6 +117,7 @@ class Responses extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/Server.php
+++ b/tests/src/Tmp/OpenAPI3/Server.php
@@ -87,6 +87,7 @@ class Server extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/ServerVariable.php
+++ b/tests/src/Tmp/OpenAPI3/ServerVariable.php
@@ -87,6 +87,7 @@ class ServerVariable extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/Tag.php
+++ b/tests/src/Tmp/OpenAPI3/Tag.php
@@ -86,6 +86,7 @@ class Tag extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/OpenAPI3/XML.php
+++ b/tests/src/Tmp/OpenAPI3/XML.php
@@ -118,6 +118,7 @@ class XML extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/ApiKeySecurity.php
+++ b/tests/src/Tmp/Swagger/ApiKeySecurity.php
@@ -117,6 +117,7 @@ class ApiKeySecurity extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/BasicAuthenticationSecurity.php
+++ b/tests/src/Tmp/Swagger/BasicAuthenticationSecurity.php
@@ -75,6 +75,7 @@ class BasicAuthenticationSecurity extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/BodyParameter.php
+++ b/tests/src/Tmp/Swagger/BodyParameter.php
@@ -130,6 +130,7 @@ class BodyParameter extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/Contact.php
+++ b/tests/src/Tmp/Swagger/Contact.php
@@ -90,6 +90,7 @@ class Contact extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/DefinitionsSchema.php
+++ b/tests/src/Tmp/Swagger/DefinitionsSchema.php
@@ -537,6 +537,7 @@ class DefinitionsSchema extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/ExternalDocs.php
+++ b/tests/src/Tmp/Swagger/ExternalDocs.php
@@ -73,6 +73,7 @@ class ExternalDocs extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/FileSchema.php
+++ b/tests/src/Tmp/Swagger/FileSchema.php
@@ -195,6 +195,7 @@ class FileSchema extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/FormDataParameterSubSchema.php
+++ b/tests/src/Tmp/Swagger/FormDataParameterSubSchema.php
@@ -423,6 +423,7 @@ class FormDataParameterSubSchema extends ClassStructure implements SchemaExporte
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/Header.php
+++ b/tests/src/Tmp/Swagger/Header.php
@@ -348,6 +348,7 @@ class Header extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/HeaderParameterSubSchema.php
+++ b/tests/src/Tmp/Swagger/HeaderParameterSubSchema.php
@@ -402,6 +402,7 @@ class HeaderParameterSubSchema extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/Info.php
+++ b/tests/src/Tmp/Swagger/Info.php
@@ -141,6 +141,7 @@ class Info extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/License.php
+++ b/tests/src/Tmp/Swagger/License.php
@@ -73,6 +73,7 @@ class License extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/Oauth2AccessCodeSecurity.php
+++ b/tests/src/Tmp/Swagger/Oauth2AccessCodeSecurity.php
@@ -149,6 +149,7 @@ class Oauth2AccessCodeSecurity extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/Oauth2ApplicationSecurity.php
+++ b/tests/src/Tmp/Swagger/Oauth2ApplicationSecurity.php
@@ -131,6 +131,7 @@ class Oauth2ApplicationSecurity extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/Oauth2ImplicitSecurity.php
+++ b/tests/src/Tmp/Swagger/Oauth2ImplicitSecurity.php
@@ -131,6 +131,7 @@ class Oauth2ImplicitSecurity extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/Oauth2PasswordSecurity.php
+++ b/tests/src/Tmp/Swagger/Oauth2PasswordSecurity.php
@@ -131,6 +131,7 @@ class Oauth2PasswordSecurity extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/Operation.php
+++ b/tests/src/Tmp/Swagger/Operation.php
@@ -240,6 +240,7 @@ class Operation extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/PathItem.php
+++ b/tests/src/Tmp/Swagger/PathItem.php
@@ -180,6 +180,7 @@ class PathItem extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/PathParameterSubSchema.php
+++ b/tests/src/Tmp/Swagger/PathParameterSubSchema.php
@@ -407,6 +407,7 @@ class PathParameterSubSchema extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/Paths.php
+++ b/tests/src/Tmp/Swagger/Paths.php
@@ -43,6 +43,7 @@ class Paths extends ClassStructure
     }
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/PrimitivesItems.php
+++ b/tests/src/Tmp/Swagger/PrimitivesItems.php
@@ -329,6 +329,7 @@ class PrimitivesItems extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/QueryParameterSubSchema.php
+++ b/tests/src/Tmp/Swagger/QueryParameterSubSchema.php
@@ -420,6 +420,7 @@ class QueryParameterSubSchema extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/Response.php
+++ b/tests/src/Tmp/Swagger/Response.php
@@ -104,6 +104,7 @@ class Response extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/Responses.php
+++ b/tests/src/Tmp/Swagger/Responses.php
@@ -83,6 +83,7 @@ class Responses extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/SwaggerSchema.php
+++ b/tests/src/Tmp/Swagger/SwaggerSchema.php
@@ -302,6 +302,7 @@ class SwaggerSchema extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/Tag.php
+++ b/tests/src/Tmp/Swagger/Tag.php
@@ -86,6 +86,7 @@ class Tag extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/Swagger/Xml.php
+++ b/tests/src/Tmp/Swagger/Xml.php
@@ -117,6 +117,7 @@ class Xml extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/ApiKeySecurity.php
+++ b/tests/src/Tmp/SwaggerMin/ApiKeySecurity.php
@@ -121,6 +121,7 @@ class ApiKeySecurity extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/BasicAuthenticationSecurity.php
+++ b/tests/src/Tmp/SwaggerMin/BasicAuthenticationSecurity.php
@@ -79,6 +79,7 @@ class BasicAuthenticationSecurity extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/BodyParameter.php
+++ b/tests/src/Tmp/SwaggerMin/BodyParameter.php
@@ -134,6 +134,7 @@ class BodyParameter extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/Contact.php
+++ b/tests/src/Tmp/SwaggerMin/Contact.php
@@ -94,6 +94,7 @@ class Contact extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/DefinitionsSchema.php
+++ b/tests/src/Tmp/SwaggerMin/DefinitionsSchema.php
@@ -636,6 +636,7 @@ class DefinitionsSchema extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/ExternalDocs.php
+++ b/tests/src/Tmp/SwaggerMin/ExternalDocs.php
@@ -77,6 +77,7 @@ class ExternalDocs extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/FileSchema.php
+++ b/tests/src/Tmp/SwaggerMin/FileSchema.php
@@ -206,6 +206,7 @@ class FileSchema extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/FormDataParameterSubSchema.php
+++ b/tests/src/Tmp/SwaggerMin/FormDataParameterSubSchema.php
@@ -483,6 +483,7 @@ class FormDataParameterSubSchema extends ClassStructure implements SchemaExporte
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/Header.php
+++ b/tests/src/Tmp/SwaggerMin/Header.php
@@ -405,6 +405,7 @@ class Header extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/HeaderParameterSubSchema.php
+++ b/tests/src/Tmp/SwaggerMin/HeaderParameterSubSchema.php
@@ -459,6 +459,7 @@ class HeaderParameterSubSchema extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/Info.php
+++ b/tests/src/Tmp/SwaggerMin/Info.php
@@ -145,6 +145,7 @@ class Info extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/License.php
+++ b/tests/src/Tmp/SwaggerMin/License.php
@@ -77,6 +77,7 @@ class License extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/Oauth2AccessCodeSecurity.php
+++ b/tests/src/Tmp/SwaggerMin/Oauth2AccessCodeSecurity.php
@@ -155,6 +155,7 @@ class Oauth2AccessCodeSecurity extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/Oauth2ApplicationSecurity.php
+++ b/tests/src/Tmp/SwaggerMin/Oauth2ApplicationSecurity.php
@@ -137,6 +137,7 @@ class Oauth2ApplicationSecurity extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/Oauth2ImplicitSecurity.php
+++ b/tests/src/Tmp/SwaggerMin/Oauth2ImplicitSecurity.php
@@ -137,6 +137,7 @@ class Oauth2ImplicitSecurity extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/Oauth2PasswordSecurity.php
+++ b/tests/src/Tmp/SwaggerMin/Oauth2PasswordSecurity.php
@@ -137,6 +137,7 @@ class Oauth2PasswordSecurity extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/Operation.php
+++ b/tests/src/Tmp/SwaggerMin/Operation.php
@@ -326,6 +326,7 @@ class Operation extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/PathItem.php
+++ b/tests/src/Tmp/SwaggerMin/PathItem.php
@@ -206,6 +206,7 @@ class PathItem extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/PathParameterSubSchema.php
+++ b/tests/src/Tmp/SwaggerMin/PathParameterSubSchema.php
@@ -464,6 +464,7 @@ class PathParameterSubSchema extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/PrimitivesItems.php
+++ b/tests/src/Tmp/SwaggerMin/PrimitivesItems.php
@@ -386,6 +386,7 @@ class PrimitivesItems extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/QueryParameterSubSchema.php
+++ b/tests/src/Tmp/SwaggerMin/QueryParameterSubSchema.php
@@ -480,6 +480,7 @@ class QueryParameterSubSchema extends ClassStructure implements SchemaExporter
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/Response.php
+++ b/tests/src/Tmp/SwaggerMin/Response.php
@@ -112,6 +112,7 @@ class Response extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/SwaggerSchema.php
+++ b/tests/src/Tmp/SwaggerMin/SwaggerSchema.php
@@ -385,6 +385,7 @@ class SwaggerSchema extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/Tag.php
+++ b/tests/src/Tmp/SwaggerMin/Tag.php
@@ -90,6 +90,7 @@ class Tag extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()

--- a/tests/src/Tmp/SwaggerMin/Xml.php
+++ b/tests/src/Tmp/SwaggerMin/Xml.php
@@ -121,6 +121,7 @@ class Xml extends ClassStructure
     /** @codeCoverageIgnoreEnd */
 
     /**
+     * @return array
      * @codeCoverageIgnoreStart
      */
     public function getXValues()


### PR DESCRIPTION
This PR enables `array` and `mixed` as default phpdoc types.