### PR TITLE
Pattern property setter will always throw an exception on valid prope…

### DIFF
--- a/src/Property/PatternPropertySetter.php
+++ b/src/Property/PatternPropertySetter.php
@@ -33,7 +33,7 @@ class PatternPropertySetter extends PhpFunction
         $this->setResult(PhpStdType::tSelf());
         $this->setBody(
             new PlaceholderString(<<<PHP
-if (preg_match(:helper::toPregPattern(self::{$patternConst->getName()}), \$name)) {
+if (!preg_match(:helper::toPregPattern(self::{$patternConst->getName()}), \$name)) {
     throw new StringException('Pattern mismatch', :stringException::PATTERN_MISMATCH);
 }
 \$this->addPatternPropertyName(self::{$patternConst->getName()}, \$name);

--- a/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
+++ b/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
@@ -477,7 +477,7 @@ class Root extends Swaggest\JsonSchema\Structure\ClassStructure
      */
     public function setXValue($name, $value)
     {
-        if (preg_match(Swaggest\JsonSchema\Helper::toPregPattern(self::X_PROPERTY_PATTERN), $name)) {
+        if (!preg_match(Swaggest\JsonSchema\Helper::toPregPattern(self::X_PROPERTY_PATTERN), $name)) {
             throw new StringException('Pattern mismatch', Swaggest\JsonSchema\Exception\StringException::PATTERN_MISMATCH);
         }
         $this->addPatternPropertyName(self::X_PROPERTY_PATTERN, $name);
@@ -512,7 +512,7 @@ class Root extends Swaggest\JsonSchema\Structure\ClassStructure
      */
     public function setZedValue($name, $value)
     {
-        if (preg_match(Swaggest\JsonSchema\Helper::toPregPattern(self::ZED_PROPERTY_PATTERN), $name)) {
+        if (!preg_match(Swaggest\JsonSchema\Helper::toPregPattern(self::ZED_PROPERTY_PATTERN), $name)) {
             throw new StringException('Pattern mismatch', Swaggest\JsonSchema\Exception\StringException::PATTERN_MISMATCH);
         }
         $this->addPatternPropertyName(self::ZED_PROPERTY_PATTERN, $name);

--- a/tests/src/PHPUnit/JsonSchema/FeatureTest.php
+++ b/tests/src/PHPUnit/JsonSchema/FeatureTest.php
@@ -3,6 +3,7 @@
 namespace Swaggest\PhpCodeBuilder\Tests\PHPUnit\JsonSchema;
 
 
+use Swaggest\JsonSchema\Exception\StringException;
 use Swaggest\JsonSchema\Schema;
 use Swaggest\PhpCodeBuilder\App\PhpApp;
 use Swaggest\PhpCodeBuilder\JsonSchema\ClassHookCallback;
@@ -88,6 +89,10 @@ class FeatureTest extends \PHPUnit_Framework_TestCase
         $e = Entity::import($data);
         $this->assertEquals(['x-sample' => 1], $e->getXValues());
         $this->assertEquals(['z-sample' => true], $e->getZValues());
+        $e->setXValue('x-sample', 2);
+        $this->assertEquals(['x-sample' => 2], $e->getXValues());
+        $e->setXValue('x-sample-3', 3);
+        $this->assertEquals(['x-sample' => 2, 'x-sample-3' => 3], $e->getXValues());
 
         $this->assertEquals(['foo1' => 'bar1', 'foo2' => 'bar2'], $e->getAdditionalPropertyValues());
 
@@ -98,6 +103,8 @@ class FeatureTest extends \PHPUnit_Framework_TestCase
         $e->{'x-sample'} = 1;
         $e->{'z-sample'} = "one";
 
+        $this->expectException(StringException::class);
+        $e->setXValue('invalid-name', 'invalid');
 
     }
 


### PR DESCRIPTION
Using `patternProperties` and using the generated code will always fail due to missing `!` in if condition