### PR TITLE
Writing defaults of class properties

### DIFF
--- a/src/JsonSchema/PhpBuilder.php
+++ b/src/JsonSchema/PhpBuilder.php
@@ -68,6 +68,12 @@ class PhpBuilder
     public $classPreparedHook;
 
     /**
+     * Use default values to initialize properties
+     * @var bool
+     */
+    public $declarePropertyDefaults = false;
+
+    /**
      * @param SchemaContract $schema
      * @param string $path
      * @return PhpAnyType
@@ -176,7 +182,7 @@ class PhpBuilder
                 $phpProperty->addMeta($property, self::SCHEMA);
                 $phpProperty->addMeta($name, self::PROPERTY_NAME);
 
-                if (!is_null($property->default)) {
+                if (!is_null($property->default) && $this->declarePropertyDefaults) {
                     $phpProperty->setDefault($property->default);
                 }
 

--- a/src/JsonSchema/PhpBuilder.php
+++ b/src/JsonSchema/PhpBuilder.php
@@ -176,6 +176,10 @@ class PhpBuilder
                 $phpProperty->addMeta($property, self::SCHEMA);
                 $phpProperty->addMeta($name, self::PROPERTY_NAME);
 
+                if (!is_null($property->default)) {
+                    $phpProperty->setDefault($property->default);
+                }
+
                 if ($this->schemaIsNullable($property)) {
                     $phpProperty->setIsMagical(true);
                 }

--- a/src/PhpFunction.php
+++ b/src/PhpFunction.php
@@ -25,6 +25,7 @@ class PhpFunction extends PhpTemplate
     private $throws;
 
     private $body;
+    protected $outputArgumentsWithDefaults = true;
     public $skipCodeCoverage = false;
 
 
@@ -99,7 +100,8 @@ PHP;
     {
         $result = '';
         foreach ($this->arguments as $argument) {
-            $result .= "{$argument->renderArgumentType()}\${$argument->getName()}{$argument->renderDefault()}, ";
+            $default = $this->outputArgumentsWithDefaults ? $argument->renderDefault() : '';
+            $result .= "{$argument->renderArgumentType()}\${$argument->getName()}{$default}, ";
         }
         if ($result) {
             $result = substr($result, 0, -2);

--- a/src/Property/Setter.php
+++ b/src/Property/Setter.php
@@ -23,6 +23,7 @@ class Setter extends PhpFunction
         );
 
         $this->skipCodeCoverage = true;
+        $this->outputArgumentsWithDefaults = false;
 
         $this->addArgument($property->getNamedVar());
 

--- a/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
+++ b/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
@@ -531,7 +531,7 @@ PHP;
     }
 
 
-    public function testClassPropertyDefaults()
+    public function testClassPropertyDefaultsActivated()
     {
         $schemaData = json_decode(<<<'JSON'
 {
@@ -563,6 +563,7 @@ JSON
         $schema = Schema::import($schemaData);
         $builder = new PhpBuilder();
         $builder->buildSetters = true;
+        $builder->declarePropertyDefaults = true;
         $class = $builder->getClass($schema, 'Root');
 
         $result = '';
@@ -671,6 +672,65 @@ class Root extends Swaggest\JsonSchema\Structure\ClassStructure
 PHP;
 
         $this->assertSame($expected, $result);
+    }
+
+    public function testClassPropertyDefaultsDeactivated()
+    {
+        $schemaData = json_decode(<<<'JSON'
+{
+    "properties": {
+        "stringDefault": {
+            "type": "string",
+            "default": "list"
+        },
+        "booleanDefault": {
+            "type": "boolean",
+            "default": false
+        },
+        "integerDefault": {
+            "type": "integer",
+            "default": 1
+        },
+        "arrayDefault": {
+            "type": "array",
+            "default": []
+        },
+        "noDefault": {
+            "type": "string"
+        }
+    }
+}
+JSON
+        );
+
+        $schema = Schema::import($schemaData);
+        $builder = new PhpBuilder();
+        $builder->buildSetters = true;
+        $class = $builder->getClass($schema, 'Root');
+
+        $result = '';
+        foreach ($builder->getGeneratedClasses() as $class) {
+            $result .= $class->class . "\n\n";
+        }
+
+        $expected = <<<'PHP'
+    /** @var string */
+    public $stringDefault;
+
+    /** @var bool */
+    public $booleanDefault;
+
+    /** @var int */
+    public $integerDefault;
+
+    /** @var array */
+    public $arrayDefault;
+
+    /** @var string */
+    public $noDefault;
+PHP;
+
+        $this->assertContains($expected, $result);
     }
 
 }

--- a/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
+++ b/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
@@ -529,4 +529,87 @@ PHP;
         $this->assertSame($expected, $result);
 
     }
+
+
+    public function testClassPropertyDefaults()
+    {
+        $schemaData = json_decode(<<<'JSON'
+{
+    "properties": {
+        "stringDefault": {
+            "type": "string",
+            "default": "list"
+        },
+        "booleanDefault": {
+            "type": "boolean",
+            "default": false
+        },
+        "integerDefault": {
+            "type": "integer",
+            "default": 1
+        },
+        "arrayDefault": {
+            "type": "array",
+            "default": []
+        },
+        "noDefault": {
+            "type": "string"
+        }
+    }
+}
+JSON
+        );
+
+        $schema = Schema::import($schemaData);
+        $builder = new PhpBuilder();
+        $class = $builder->getClass($schema, 'Root');
+
+        $result = '';
+        foreach ($builder->getGeneratedClasses() as $class) {
+            $result .= $class->class . "\n\n";
+        }
+
+        $expected = <<<'PHP'
+class Root extends Swaggest\JsonSchema\Structure\ClassStructure
+{
+    /** @var string */
+    public $stringDefault = 'list';
+
+    /** @var bool */
+    public $booleanDefault = false;
+
+    /** @var int */
+    public $integerDefault = 1;
+
+    /** @var array */
+    public $arrayDefault = array (
+    );
+
+    /** @var string */
+    public $noDefault;
+
+    /**
+     * @param Swaggest\JsonSchema\Constraint\Properties|static $properties
+     * @param Swaggest\JsonSchema\Schema $ownerSchema
+     */
+    public static function setUpProperties($properties, Swaggest\JsonSchema\Schema $ownerSchema)
+    {
+        $properties->stringDefault = Swaggest\JsonSchema\Schema::string();
+        $properties->stringDefault->default = "list";
+        $properties->booleanDefault = Swaggest\JsonSchema\Schema::boolean();
+        $properties->booleanDefault->default = false;
+        $properties->integerDefault = Swaggest\JsonSchema\Schema::integer();
+        $properties->integerDefault->default = 1;
+        $properties->arrayDefault = Swaggest\JsonSchema\Schema::arr();
+        $properties->arrayDefault->default = array();
+        $properties->noDefault = Swaggest\JsonSchema\Schema::string();
+    }
+}
+
+
+PHP;
+
+        $this->assertSame($expected, $result);
+    }
+
 }

--- a/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
+++ b/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
@@ -562,6 +562,7 @@ JSON
 
         $schema = Schema::import($schemaData);
         $builder = new PhpBuilder();
+        $builder->buildSetters = true;
         $class = $builder->getClass($schema, 'Root');
 
         $result = '';
@@ -604,6 +605,66 @@ class Root extends Swaggest\JsonSchema\Structure\ClassStructure
         $properties->arrayDefault->default = array();
         $properties->noDefault = Swaggest\JsonSchema\Schema::string();
     }
+
+    /**
+     * @param string $stringDefault
+     * @return $this
+     * @codeCoverageIgnoreStart
+     */
+    public function setStringDefault($stringDefault)
+    {
+        $this->stringDefault = $stringDefault;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @param bool $booleanDefault
+     * @return $this
+     * @codeCoverageIgnoreStart
+     */
+    public function setBooleanDefault($booleanDefault)
+    {
+        $this->booleanDefault = $booleanDefault;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @param int $integerDefault
+     * @return $this
+     * @codeCoverageIgnoreStart
+     */
+    public function setIntegerDefault($integerDefault)
+    {
+        $this->integerDefault = $integerDefault;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @param array $arrayDefault
+     * @return $this
+     * @codeCoverageIgnoreStart
+     */
+    public function setArrayDefault($arrayDefault)
+    {
+        $this->arrayDefault = $arrayDefault;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @param string $noDefault
+     * @return $this
+     * @codeCoverageIgnoreStart
+     */
+    public function setNoDefault($noDefault)
+    {
+        $this->noDefault = $noDefault;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
 }
 
 


### PR DESCRIPTION
If you work with the rendered classes to export data, there are no default values for the class properties. With this pull request the default values will be written to the generated files. The setter methods will not get any defaults, because this should only be done in the definition of the class properties.

Class properties (first without a default value):
```php
    /** @var Taxonomy TBD. */
    public $taxonomy;

    /** @var string */
    public $type = 'article';

    /** @var string The version of this object in major.minor.patch format. See also: https://semver.org/. */
    public $version = '0.0.0';
```

Setter would be the same as before:
```php
public function setVersion($version)
{
    $this->version = $version;
    return $this;
}
```