### PR TITLE
Exclude objects from default class property values

### DIFF
--- a/src/PhpCode.php
+++ b/src/PhpCode.php
@@ -134,6 +134,42 @@ class PhpCode extends PhpTemplate
     public static function varExport($value)
     {
         /** @var string $result */
+        $result = '';
+
+        if (is_array($value)) {
+            if (count($value) === 0) {
+                return '[]';
+            }
+
+            $i = 0;
+            $sequential = true;
+            foreach ($value as $k => $v) {
+                if ($k !== $i) {
+                    $sequential = false;
+                    break;
+                }
+                ++$i;
+            }
+            $t = new self();
+            $result .= "[\n";
+            if ($sequential) {
+                foreach ($value as $item) {
+                    $result .= $t->padLines('    ', self::varExport($item), false) . ",\n";
+                }
+            } else {
+                foreach ($value as $key => $item) {
+                    $result .= $t->padLines('    ', self::varExport($key) . ' => ' . self::varExport($item), false) . ",\n";
+                }
+            }
+            $result .= "]";
+            return $result;
+        }
+
+        if ($value instanceof \stdClass) {
+            return '(object)' . self::varExport((array)$value);
+        }
+
+
         $result = var_export($value, true);
         $result = str_replace("stdClass::__set_state", "(object)", $result);
         $result = str_replace("array (\n", "array(\n", $result);

--- a/src/PhpNamedVar.php
+++ b/src/PhpNamedVar.php
@@ -101,7 +101,10 @@ class PhpNamedVar
         if ($this->default instanceof PhpTemplate) {
             $result = $this->default->render();
         } else {
-            $result = var_export($this->default, true);
+            $result = PhpCode::varExport($this->default);
+            if (strpos($result, '::__set_state(') !== false || strpos($result, '(object)') !== false) {
+                return '';
+            }
         }
 
         return ' = ' . $result;

--- a/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
+++ b/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
@@ -592,7 +592,7 @@ class Root extends Swaggest\JsonSchema\Structure\ClassStructure
     public $integerDefault = 1;
 
     /** @var array */
-    public $arrayDefault = array();
+    public $arrayDefault = [];
 
     /** @var mixed */
     public $objectDefault;
@@ -616,22 +616,20 @@ class Root extends Swaggest\JsonSchema\Structure\ClassStructure
         $properties->integerDefault = Swaggest\JsonSchema\Schema::integer();
         $properties->integerDefault->default = 1;
         $properties->arrayDefault = Swaggest\JsonSchema\Schema::arr();
-        $properties->arrayDefault->default = array();
+        $properties->arrayDefault->default = [];
         $properties->objectDefault = Swaggest\JsonSchema\Schema::object();
-        $properties->objectDefault->default = (object)array(
+        $properties->objectDefault->default = (object)[
             'key' => 'val',
-        );
+        ];
         $properties->arrayOfObjectsDefault = Swaggest\JsonSchema\Schema::arr();
-        $properties->arrayOfObjectsDefault->default = array(
-            0 => 
-            (object) array(
-                 'key' => 'val',
-            ),
-            1 => 
-            (object) array(
-                 'key' => 'val',
-            ),
-        );
+        $properties->arrayOfObjectsDefault->default = [
+            (object)[
+                'key' => 'val',
+            ],
+            (object)[
+                'key' => 'val',
+            ],
+        ];
         $properties->noDefault = Swaggest\JsonSchema\Schema::string();
     }
 
@@ -765,7 +763,7 @@ JSON
             $result .= $class->class . "\n\n";
         }
 
-        $expected = <<<'PHP'
+        $expected = <<<'PHPfragment'
     /** @var string */
     public $stringDefault;
 
@@ -780,7 +778,7 @@ JSON
 
     /** @var string */
     public $noDefault;
-PHP;
+PHPfragment;
 
         $this->assertContains($expected, $result);
     }

--- a/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
+++ b/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
@@ -552,6 +552,14 @@ PHP;
             "type": "array",
             "default": []
         },
+        "objectDefault": {
+            "type": "object",
+            "default": {"key":"val"}
+        },
+        "arrayOfObjectsDefault": {
+            "type": "array",
+            "default": [{"key":"val"},{"key":"val"}]
+        },
         "noDefault": {
             "type": "string"
         }
@@ -584,8 +592,13 @@ class Root extends Swaggest\JsonSchema\Structure\ClassStructure
     public $integerDefault = 1;
 
     /** @var array */
-    public $arrayDefault = array (
-    );
+    public $arrayDefault = array();
+
+    /** @var mixed */
+    public $objectDefault;
+
+    /** @var array */
+    public $arrayOfObjectsDefault;
 
     /** @var string */
     public $noDefault;
@@ -604,6 +617,21 @@ class Root extends Swaggest\JsonSchema\Structure\ClassStructure
         $properties->integerDefault->default = 1;
         $properties->arrayDefault = Swaggest\JsonSchema\Schema::arr();
         $properties->arrayDefault->default = array();
+        $properties->objectDefault = Swaggest\JsonSchema\Schema::object();
+        $properties->objectDefault->default = (object)array(
+            'key' => 'val',
+        );
+        $properties->arrayOfObjectsDefault = Swaggest\JsonSchema\Schema::arr();
+        $properties->arrayOfObjectsDefault->default = array(
+            0 => 
+            (object) array(
+                 'key' => 'val',
+            ),
+            1 => 
+            (object) array(
+                 'key' => 'val',
+            ),
+        );
         $properties->noDefault = Swaggest\JsonSchema\Schema::string();
     }
 
@@ -651,6 +679,30 @@ class Root extends Swaggest\JsonSchema\Structure\ClassStructure
     public function setArrayDefault($arrayDefault)
     {
         $this->arrayDefault = $arrayDefault;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @param mixed $objectDefault
+     * @return $this
+     * @codeCoverageIgnoreStart
+     */
+    public function setObjectDefault($objectDefault)
+    {
+        $this->objectDefault = $objectDefault;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @param array $arrayOfObjectsDefault
+     * @return $this
+     * @codeCoverageIgnoreStart
+     */
+    public function setArrayOfObjectsDefault($arrayOfObjectsDefault)
+    {
+        $this->arrayOfObjectsDefault = $arrayOfObjectsDefault;
         return $this;
     }
     /** @codeCoverageIgnoreEnd */

--- a/tests/src/Tmp/Swagger/DefinitionsSchema.php
+++ b/tests/src/Tmp/Swagger/DefinitionsSchema.php
@@ -143,7 +143,7 @@ class DefinitionsSchema extends ClassStructure implements SchemaExporter
         $properties->additionalProperties = new Schema();
         $properties->additionalProperties->anyOf[0] = DefinitionsSchema::schema();
         $properties->additionalProperties->anyOf[1] = Schema::boolean();
-        $properties->additionalProperties->default = (object)array();
+        $properties->additionalProperties->default = (object)[];
         $properties->type = HttpJsonSchemaOrgDraft04SchemaPropertiesType::schema();
         $properties->items = new Schema();
         $properties->items->anyOf[0] = DefinitionsSchema::schema();
@@ -151,13 +151,13 @@ class DefinitionsSchema extends ClassStructure implements SchemaExporter
         $propertiesItemsAnyOf1->items = DefinitionsSchema::schema();
         $propertiesItemsAnyOf1->minItems = 1;
         $properties->items->anyOf[1] = $propertiesItemsAnyOf1;
-        $properties->items->default = (object)array();
+        $properties->items->default = (object)[];
         $properties->allOf = Schema::arr();
         $properties->allOf->items = DefinitionsSchema::schema();
         $properties->allOf->minItems = 1;
         $properties->properties = Schema::object();
         $properties->properties->additionalProperties = DefinitionsSchema::schema();
-        $properties->properties->default = (object)array();
+        $properties->properties->default = (object)[];
         $properties->discriminator = Schema::string();
         $properties->readOnly = Schema::boolean();
         $properties->readOnly->default = false;

--- a/tests/src/Tmp/SwaggerMin/DefinitionsSchema.php
+++ b/tests/src/Tmp/SwaggerMin/DefinitionsSchema.php
@@ -210,7 +210,7 @@ class DefinitionsSchema extends ClassStructure implements SchemaExporter
         $properties->additionalProperties = new Schema();
         $properties->additionalProperties->anyOf[0] = DefinitionsSchema::schema();
         $properties->additionalProperties->anyOf[1] = Schema::boolean();
-        $properties->additionalProperties->default = (object)array();
+        $properties->additionalProperties->default = (object)[];
         $properties->type = new Schema();
         $propertiesTypeAnyOf0 = new Schema();
         $propertiesTypeAnyOf0->enum = array(
@@ -246,13 +246,13 @@ class DefinitionsSchema extends ClassStructure implements SchemaExporter
         $propertiesItemsAnyOf1->items = DefinitionsSchema::schema();
         $propertiesItemsAnyOf1->minItems = 1;
         $properties->items->anyOf[1] = $propertiesItemsAnyOf1;
-        $properties->items->default = (object)array();
+        $properties->items->default = (object)[];
         $properties->allOf = Schema::arr();
         $properties->allOf->items = DefinitionsSchema::schema();
         $properties->allOf->minItems = 1;
         $properties->properties = Schema::object();
         $properties->properties->additionalProperties = DefinitionsSchema::schema();
-        $properties->properties->default = (object)array();
+        $properties->properties->default = (object)[];
         $properties->discriminator = Schema::string();
         $properties->readOnly = Schema::boolean();
         $properties->readOnly->default = false;


### PR DESCRIPTION
Properties with object values usually need to be imported into an instance of named class, default value of php property does not allow dynamic expressions (like class constructor) and raw `\stdClass` value can be inconsistent with expected property type. 

This PR disables default value rending if it contains object.