### PR TITLE
Creating getter and setter for additional properties on boolean true

### DIFF
--- a/tests/resources/JsonSchema/AdvancedTest/testBuildingAdditionalPropertyMethodsOnTrue-new-behavior.txt
+++ b/tests/resources/JsonSchema/AdvancedTest/testBuildingAdditionalPropertyMethodsOnTrue-new-behavior.txt
@@ -1,0 +1,47 @@
+/**
+ * @method static mixed import($data, Swaggest\JsonSchema\Context $options = null)
+ */
+class Root extends Swaggest\JsonSchema\Structure\ClassStructure
+{
+    /**
+     * @param Swaggest\JsonSchema\Constraint\Properties|static $properties
+     * @param Swaggest\JsonSchema\Schema $ownerSchema
+     */
+    public static function setUpProperties($properties, Swaggest\JsonSchema\Schema $ownerSchema)
+    {
+        $ownerSchema->type = Swaggest\JsonSchema\Schema::OBJECT;
+        $ownerSchema->additionalProperties = true;
+    }
+
+    /**
+     * @return array
+     * @codeCoverageIgnoreStart
+     */
+    public function getAdditionalPropertyValues()
+    {
+        $result = array();
+        if (!$names = $this->getAdditionalPropertyNames()) {
+            return $result;
+        }
+        foreach ($names as $name) {
+            $result[$name] = $this->$name;
+        }
+        return $result;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @param string $name
+     * @param mixed $value
+     * @return self
+     * @codeCoverageIgnoreStart
+     */
+    public function setAdditionalPropertyValue($name, $value)
+    {
+        $this->addAdditionalPropertyName($name);
+        $this->{$name} = $value;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
+}
+

--- a/tests/resources/JsonSchema/AdvancedTest/testBuildingAdditionalPropertyMethodsOnTrue-old-behavior.txt
+++ b/tests/resources/JsonSchema/AdvancedTest/testBuildingAdditionalPropertyMethodsOnTrue-old-behavior.txt
@@ -1,0 +1,16 @@
+/**
+ * @method static mixed import($data, Swaggest\JsonSchema\Context $options = null)
+ */
+class Root extends Swaggest\JsonSchema\Structure\ClassStructure
+{
+    /**
+     * @param Swaggest\JsonSchema\Constraint\Properties|static $properties
+     * @param Swaggest\JsonSchema\Schema $ownerSchema
+     */
+    public static function setUpProperties($properties, Swaggest\JsonSchema\Schema $ownerSchema)
+    {
+        $ownerSchema->type = Swaggest\JsonSchema\Schema::OBJECT;
+        $ownerSchema->additionalProperties = true;
+    }
+}
+

--- a/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
+++ b/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
@@ -733,4 +733,43 @@ PHP;
         $this->assertContains($expected, $result);
     }
 
+    public function testBuildingAdditionalPropertyMethodsOnTrue()
+    {
+        $schemaData = json_decode(<<<'JSON'
+{
+  "type": "object",
+  "additionalProperties": true
+}
+JSON
+        );
+
+        // Keeping the old behavior
+        $schema = Schema::import($schemaData);
+        $builder = new PhpBuilder();
+        $class = $builder->getClass($schema, 'Root');
+
+        $result = '';
+        foreach ($builder->getGeneratedClasses() as $class) {
+            $result .= $class->class . "\n\n";
+        }
+
+        $expected = file_get_contents(__DIR__ . '/../../../resources/JsonSchema/AdvancedTest/' . __FUNCTION__ . '-old-behavior.txt');
+
+        $this->assertSame($expected, $result, 'Getter and setter not created (old behavior - flag: false)');
+
+        // Testing the new behavior with setted flag
+        $schema = Schema::import($schemaData);
+        $builder = new PhpBuilder();
+        $builder->buildAdditionalPropertyMethodsOnTrue = true;
+        $class = $builder->getClass($schema, 'Root');
+
+        $result = '';
+        foreach ($builder->getGeneratedClasses() as $class) {
+            $result .= $class->class . "\n\n";
+        }
+
+        $expected = file_get_contents(__DIR__ . '/../../../resources/JsonSchema/AdvancedTest/' . __FUNCTION__ . '-new-behavior.txt');
+
+        $this->assertSame($expected, $result, 'Getter and setter created (new behavior - flag: true)');
+    }
 }


### PR DESCRIPTION
Best practice to work with additional properties are the generated methods `setAdditionalPropertyValue` and `getAdditionalPropertyValues`. In JSON schema you can set `"additionalProperties": true`. So far the methods will not been created, because you need a valid _Schema_ instance (in JSON Schema: `"additionalProperties": {"type": "string"}`)

This pull request will created these methods with `PhpStdType::mixed()` as _Type_. You have to activate this behavior with a flag:
```php
$builder = new PhpBuilder();
$builder->buildAdditionalPropertyMethodsOnTrue = true;
```
