### PR TITLE
feat: avoid duplicated symbol declarations

### DIFF
--- a/src/App/PhpApp.php
+++ b/src/App/PhpApp.php
@@ -64,6 +64,7 @@ class PhpApp extends App
         $file = new PhpFile();
         if ($ns) {
             $file->setNamespace($ns);
+            $file->getNamespaces()->add($class->getFullyQualifiedName());
         }
         $file->getCode()->addSnippet($class);
         $this->files[$filepath] = $file;

--- a/tests/resources/duplicate-symbol-declaration-schema.json
+++ b/tests/resources/duplicate-symbol-declaration-schema.json
@@ -1,0 +1,30 @@
+{
+  "title": "Standalone Image",
+  "meta:class": "SomeThing",
+  "type": "object",
+  "properties": {
+      "inline_elements": {
+          "type": "array",
+          "items": {
+              "anyOf": [
+                  { "$ref": "#/definitions/InlineElementImage" }
+              ]
+          }
+      }
+  },
+  "definitions": {
+      "InlineElementImage": {
+          "meta:class": "SomeThing",
+          "meta:namespace": "InlineElements",
+          "type": "object",
+          "properties": {
+              "height": {
+                  "type": "number"
+              },
+              "width": {
+                  "type": "number"
+              }
+          }
+      }
+  }
+}

--- a/tests/src/PHPUnit/JsonSchema/DuplicateSymbolDeclarationTest.php
+++ b/tests/src/PHPUnit/JsonSchema/DuplicateSymbolDeclarationTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Swaggest\PhpCodeBuilder\Tests\PHPUnit\JsonSchema;
+
+
+use Swaggest\JsonSchema\Exception\StringException;
+use Swaggest\JsonSchema\Schema;
+use Swaggest\PhpCodeBuilder\App\PhpApp;
+use Swaggest\PhpCodeBuilder\JsonSchema\ClassHookCallback;
+use Swaggest\PhpCodeBuilder\JsonSchema\PhpBuilder;
+use Swaggest\PhpCodeBuilder\PhpClass;
+use Swaggest\PhpCodeBuilder\Tests\Tmp\DuplicateSymbolDeclaration\SomeThing;
+use Swaggest\PhpCodeBuilder\Tests\Tmp\DuplicateSymbolDeclaration\InlineElements\SomeThing as InlineElementSomeThing;
+
+class DuplicateSymbolDeclarationTest extends \PHPUnit_Framework_TestCase
+{
+    private $nsItem = "DuplicateSymbolDeclaration";
+
+    public function testGeneration()
+    {
+        $schemaData = json_decode(file_get_contents(__DIR__ . '/../../../resources/duplicate-symbol-declaration-schema.json'));
+        $schema = Schema::import($schemaData);
+
+        $appPath = realpath(__DIR__ . '/../../Tmp') . '/' . $this->nsItem;
+        $appNs = 'Swaggest\PhpCodeBuilder\Tests\Tmp\\' . $this->nsItem;
+
+        $app = new PhpApp();
+        $app->setNamespaceRoot($appNs, '.');
+
+        $builder = new PhpBuilder();
+        $builder->buildSetters = true;
+        $builder->makeEnumConstants = true;
+
+        $builder->classCreatedHook = new ClassHookCallback(
+            function (PhpClass $class, $path, $schema) use ($app, $appNs) {
+                $namespace = $schema->{'meta:namespace'};
+                $class->setNamespace($appNs . ($namespace ? '\\' . $namespace : ''));
+                $class->setName($schema->{'meta:class'});
+                $app->addClass($class);
+            }
+        );
+
+        $builder->getType($schema);
+        $app->clearOldFiles($appPath);
+        $app->store($appPath);
+
+        exec('git diff ' . $appPath, $out);
+        $out = implode("\n", $out);
+        $this->assertSame('', $out, "Generated files changed");
+
+    }
+
+
+    public function testGeneratedEntity()
+    {
+        $data = (object)[
+            'inline_elements' => [
+                (object)[
+                    'width' => 640,
+                    'height' => 480,
+                ],
+            ],
+        ];
+
+        $s = SomeThing::import($data);
+
+        $this->assertInstanceOf(SomeThing::class, $s);
+        $this->assertCount(1, $s->inlineElements);
+        $this->assertInstanceOf(
+            InlineElementSomeThing::class,
+            $s->inlineElements[0],
+        );
+        $this->assertEquals(640, $s->inlineElements[0]->width);
+    }
+
+}

--- a/tests/src/Tmp/DuplicateSymbolDeclaration/InlineElements/SomeThing.php
+++ b/tests/src/Tmp/DuplicateSymbolDeclaration/InlineElements/SomeThing.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @file ATTENTION!!! The code below was carefully crafted by a mean machine.
+ * Please consider to NOT put any emotional human-generated modifications as the splendid AI will throw them away with no mercy.
+ */
+
+namespace Swaggest\PhpCodeBuilder\Tests\Tmp\DuplicateSymbolDeclaration\InlineElements;
+
+use Swaggest\JsonSchema\Constraint\Properties;
+use Swaggest\JsonSchema\Schema;
+use Swaggest\JsonSchema\Structure\ClassStructure;
+
+
+class SomeThing extends ClassStructure
+{
+    /** @var float */
+    public $height;
+
+    /** @var float */
+    public $width;
+
+    /**
+     * @param Properties|static $properties
+     * @param Schema $ownerSchema
+     */
+    public static function setUpProperties($properties, Schema $ownerSchema)
+    {
+        $properties->height = Schema::number();
+        $properties->width = Schema::number();
+        $ownerSchema->type = Schema::OBJECT;
+        $ownerSchema->setFromRef('#/definitions/InlineElementImage');
+    }
+
+    /**
+     * @param float $height
+     * @return $this
+     * @codeCoverageIgnoreStart
+     */
+    public function setHeight($height)
+    {
+        $this->height = $height;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
+
+    /**
+     * @param float $width
+     * @return $this
+     * @codeCoverageIgnoreStart
+     */
+    public function setWidth($width)
+    {
+        $this->width = $width;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
+}

--- a/tests/src/Tmp/DuplicateSymbolDeclaration/SomeThing.php
+++ b/tests/src/Tmp/DuplicateSymbolDeclaration/SomeThing.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @file ATTENTION!!! The code below was carefully crafted by a mean machine.
+ * Please consider to NOT put any emotional human-generated modifications as the splendid AI will throw them away with no mercy.
+ */
+
+namespace Swaggest\PhpCodeBuilder\Tests\Tmp\DuplicateSymbolDeclaration;
+
+use Swaggest\JsonSchema\Constraint\Properties;
+use Swaggest\JsonSchema\Schema;
+use Swaggest\JsonSchema\Structure\ClassStructure;
+use Swaggest\PhpCodeBuilder\Tests\Tmp\DuplicateSymbolDeclaration\InlineElements\SomeThing as SomeThing1;
+
+
+class SomeThing extends ClassStructure
+{
+    /** @var SomeThing1[]|array */
+    public $inlineElements;
+
+    /**
+     * @param Properties|static $properties
+     * @param Schema $ownerSchema
+     */
+    public static function setUpProperties($properties, Schema $ownerSchema)
+    {
+        $properties->inlineElements = Schema::arr();
+        $properties->inlineElements->items = new Schema();
+        $properties->inlineElements->items->anyOf[0] = SomeThing1::schema();
+        $ownerSchema->addPropertyMapping('inline_elements', self::names()->inlineElements);
+        $ownerSchema->type = Schema::OBJECT;
+        $ownerSchema->title = "Standalone Image";
+    }
+
+    /**
+     * @param SomeThing1[]|array $inlineElements
+     * @return $this
+     * @codeCoverageIgnoreStart
+     */
+    public function setInlineElements($inlineElements)
+    {
+        $this->inlineElements = $inlineElements;
+        return $this;
+    }
+    /** @codeCoverageIgnoreEnd */
+}


### PR DESCRIPTION
If you have the same named classes in different namespaces, there will be duplicated symbol declarations in the generated php files.

```php
namespace Foo;

# [...]
use Foo\Bar\SomeThing; # Duplicated symbol declaration

class SomeThing extends ClassStructure  # Duplicated symbol declaration
{
    /** @var SomeThing[]|array */
    public $elements;

    # [...]
}
```

This throws the following exception:

`PHP Fatal error:  Cannot declare class Foo\SomeThing because the name is already in use ...`

With this pull request the fully qualified name of the class will be added to the `PhpNamespace` object of each added class to the `PhpApp` object. The output will be the following:

```php
namespace Foo;

# [...]
use Foo\Bar\Something as SomeThing1;

class SomeThing extends ClassStructure
{
    /** @var SomeThing1[]|array */
    public $elements;

    # [...]
}
```