### PR TITLE
Fix for json fields containing a dollar sign (Issue #59)

### DIFF
--- a/src/JsonSchema/SchemaBuilder.php
+++ b/src/JsonSchema/SchemaBuilder.php
@@ -396,7 +396,15 @@ class SchemaBuilder
             } elseif ($value instanceof \stdClass) {
                 $export = '(object)' . PhpCode::varExport((array)$value);
             } elseif (is_string($value)) {
-                $export = '"' . str_replace(array('\\', "\n", "\r", "\t", '"', '${', '{$'), array('\\\\', '\n', '\r', '\t', '\"', '\${', '{\$'), $value) . '"';
+                switch ($key) {
+                    case 'pattern':
+                        $export = '"' . str_replace(array('\\', "\n", "\r", "\t", '"', '${', '{$'), array('\\\\', '\n', '\r', '\t', '\"', '\${', '{\$'), $value) . '"';
+                        break;
+                    default:
+                        $export = '"' . str_replace(array('\\', "\n", "\r", "\t", '"', '$'), array('\\\\', '\n', '\r', '\t', '\"', '\$'), $value) . '"';
+                        break;
+                }
+                
             } else {
                 $export = PhpCode::varExport($value);
             }

--- a/tests/src/PHPUnit/Issues/Issue59Test.php
+++ b/tests/src/PHPUnit/Issues/Issue59Test.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Swaggest\PhpCodeBuilder\Tests\PHPUnit\Issues;
+
+use Swaggest\JsonSchema\Exception\ConstException;
+use Swaggest\JsonSchema\Exception\ObjectException;
+use Swaggest\JsonSchema\Schema;
+use Swaggest\PhpCodeBuilder\App\PhpApp;
+use Swaggest\PhpCodeBuilder\JsonSchema\ClassHookCallback;
+use Swaggest\PhpCodeBuilder\JsonSchema\PhpBuilder;
+use Swaggest\PhpCodeBuilder\PhpClass;
+use Swaggest\PhpCodeBuilder\Tests\Tmp\Issue59\Sample;
+
+/**
+ * @see https://github.com/swaggest/php-code-builder/issues/59
+ */
+class Issue59Test extends \PHPUnit_Framework_TestCase
+{
+    function testIssue59()
+    {
+        $schemaJson = <<<'JSON'
+{
+  "type": "object",
+  "description": "Description with $dollar sign",
+  "properties": {
+    "foo": {
+      "type": "string"
+    }
+  }
+}
+JSON;
+
+        $appPath = realpath(__DIR__ . '/../../Tmp') . '/Issue59';
+        $appNs = 'Swaggest\PhpCodeBuilder\Tests\Tmp\\Issue59';
+
+        $app = new PhpApp();
+        $app->setNamespaceRoot($appNs, '.');
+
+        $schema = Schema::import(json_decode($schemaJson));
+        $builder = new PhpBuilder();
+        $builder->buildSetters = false;
+        $builder->makeEnumConstants = true;
+        $builder->skipSchemaDescriptions = false;
+
+        $builder->classCreatedHook = new ClassHookCallback(
+            function (PhpClass $class, $path, $schema) use ($app, $appNs) {
+                $class->setNamespace($appNs);
+                if ('#' === $path) {
+                    $class->setName('Sample'); // Class name for root schema
+                }
+                $app->addClass($class);
+            }
+        );
+
+
+        $builder->getType($schema);
+
+        $app->clearOldFiles($appPath);
+        $app->store($appPath);
+
+        exec('git diff ' . $appPath, $out);
+        $out = implode("\n", $out);
+        $this->assertSame('', $out, "Generated files changed");
+    }
+
+
+    function testGeneratedValid()
+    {
+        Sample::import((object)array('foo' => 'abc'));
+    }
+
+}

--- a/tests/src/Tmp/Issue59/Sample.php
+++ b/tests/src/Tmp/Issue59/Sample.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @file ATTENTION!!! The code below was carefully crafted by a mean machine.
+ * Please consider to NOT put any emotional human-generated modifications as the splendid AI will throw them away with no mercy.
+ */
+
+namespace Swaggest\PhpCodeBuilder\Tests\Tmp\Issue59;
+
+use Swaggest\JsonSchema\Constraint\Properties;
+use Swaggest\JsonSchema\Schema;
+use Swaggest\JsonSchema\Structure\ClassStructure;
+
+
+class Sample extends ClassStructure
+{
+    /** @var string */
+    public $foo;
+
+    /**
+     * @param Properties|static $properties
+     * @param Schema $ownerSchema
+     */
+    public static function setUpProperties($properties, Schema $ownerSchema)
+    {
+        $properties->foo = Schema::string();
+        $ownerSchema->type = Schema::OBJECT;
+        $ownerSchema->description = "Description with \$dollar sign";
+    }
+}


### PR DESCRIPTION
This PR contains a proposed fix for issue #59

I've noticed that the current escaping is custom tailored for the "pattern" key, which contains a regular expression.

I understand that those need special treatment and a standalone `$` sign is not expected(?) there. But other fields (titles, description, ids) could contain dollar signs at any positions.

I've added unit tests and made sure everything else works as well.

Please review this PR and add any suggestions.